### PR TITLE
[FIX] odoo-tester: Python 3.8 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora
 
 # Odoo version
 #


### PR DESCRIPTION
User-story/11119

Signed-off-by: Kevin Dwyer <kevin.dwyer@unipart.io>

Remove the restriction on the Fedora version added in 6fb3445.
Allow the tests to run on the latest Fedora version, using the default
Python 3.